### PR TITLE
Addition of IsoTech milliK resource class

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Developers
 ==========
 
 * Joseph Borbely <joseph.borbely@measurement.govt.nz>
+* Rebecca Hawke <rebecca.hawke@measurement.govt.nz>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.2.0 (in development)
   - ``find-equipment`` console script
   - :class:`~msl.equipment.connection_gpib.ConnectionGPIB` class
   - :class:`~msl.equipment.resources.greisinger.gmh3000.GMH3000` resource
+  - :class:`~msl.equipment.resources.isotech.millik.MilliK` resource
 
 * Fixed
 

--- a/docs/_api/msl.equipment.resources.isotech.millik.rst
+++ b/docs/_api/msl.equipment.resources.isotech.millik.rst
@@ -1,0 +1,7 @@
+msl.equipment.resources.isotech.millik module
+=============================================
+
+.. automodule:: msl.equipment.resources.isotech.millik
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/_api/msl.equipment.resources.isotech.rst
+++ b/docs/_api/msl.equipment.resources.isotech.rst
@@ -1,0 +1,15 @@
+msl.equipment.resources.isotech package
+=======================================
+
+.. automodule:: msl.equipment.resources.isotech
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   msl.equipment.resources.isotech.millik

--- a/docs/_api/msl.equipment.resources.rst
+++ b/docs/_api/msl.equipment.resources.rst
@@ -26,6 +26,7 @@ Subpackages
     msl.equipment.resources.electron_dynamics
     msl.equipment.resources.energetiq
     msl.equipment.resources.greisinger
+    msl.equipment.resources.isotech
     msl.equipment.resources.mks_instruments
     msl.equipment.resources.nkt
     msl.equipment.resources.omega

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -37,7 +37,7 @@ MSL Resources are specific classes that are used to communicate with the equipme
 
   * :class:`~msl.equipment.resources.greisinger.gmh3000.GMH3000` -- GMH 3000 Series thermometer
 
-* Isotech_
+* IsoTech_
 
   * :class:`~msl.equipment.resources.isotech.millik.MilliK` -- IsoTech milliK Precision Thermometer
 
@@ -217,4 +217,4 @@ Please follow the `style guide`_.
 .. _Energetiq: https://www.energetiq.com/
 .. _Raicol Crystals: https://raicol.com/
 .. _Greisinger: https://www.greisinger.de/
-.. _Isotech: https://isotech.co.uk/
+.. _IsoTech: https://isotech.co.uk/

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -37,6 +37,10 @@ MSL Resources are specific classes that are used to communicate with the equipme
 
   * :class:`~msl.equipment.resources.greisinger.gmh3000.GMH3000` -- GMH 3000 Series thermometer
 
+* Isotech_
+
+  * :class:`~msl.equipment.resources.isotech.millik.MilliK` -- IsoTech milliK Precision Thermometer
+
 * `MKS Instruments`_
 
   * :class:`~msl.equipment.resources.mks_instruments.pr4000b.PR4000B` -- Flow and Pressure controller
@@ -213,3 +217,4 @@ Please follow the `style guide`_.
 .. _Energetiq: https://www.energetiq.com/
 .. _Raicol Crystals: https://raicol.com/
 .. _Greisinger: https://www.greisinger.de/
+.. _Isotech: https://isotech.co.uk/

--- a/msl/equipment/exceptions.py
+++ b/msl/equipment/exceptions.py
@@ -74,8 +74,8 @@ class GreisingerError(MSLConnectionError):
     """Exception for equipment from Greisinger."""
 
 
-class IsotechError(MSLConnectionError):
-    """Exception for equipment from Isotech."""
+class IsoTechError(MSLConnectionError):
+    """Exception for equipment from IsoTech."""
 
 
 class MKSInstrumentsError(MSLConnectionError):

--- a/msl/equipment/exceptions.py
+++ b/msl/equipment/exceptions.py
@@ -74,6 +74,10 @@ class GreisingerError(MSLConnectionError):
     """Exception for equipment from Greisinger."""
 
 
+class IsotechError(MSLConnectionError):
+    """Exception for equipment from Isotech."""
+
+
 class MKSInstrumentsError(MSLConnectionError):
     """Exception for equipment from MKS Instruments."""
 

--- a/msl/equipment/resources/isotech/__init__.py
+++ b/msl/equipment/resources/isotech/__init__.py
@@ -1,0 +1,6 @@
+"""
+Resources for equipment from `IsoTech <https://isotech.co.uk/>`_.
+"""
+from __future__ import annotations
+
+from .millik import MilliK

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from msl.equipment.resources import register
-from msl.equipment.exceptions import IsotechError
+from msl.equipment.exceptions import IsoTechError
 from msl.equipment.connection_serial import ConnectionSerial
 
 

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -133,21 +133,22 @@ class MilliK:
 
         return readings
 
-    def read_all_channels(self, n: int = 1) -> tuple[list[float], list[float]]:
+    def read_all_channels(self, n: int = 1) -> tuple[list[int], list[float]]:
         """Read from all configured channels using the conditions defined by :meth:`.configure_resistance_measurement`.
 
         :param n: The number of readings to average for each returned value.
         :return: A tuple of lists of channel numbers and readings from all configured channels.
         """
+        channels = sorted(self.channel_configuration)
         results = []
-        for c in sorted(self.channel_configuration):
+        for c in channels:
             readings = self.read_channel(c, n)
             if n == 1:  # readings is a single float value
                 results.append(readings)
             else:       # average multiple readings
                 results.append(sum(readings)/len(readings))
 
-        return sorted(self.channel_configuration), results
+        return channels, results
 
     def disconnect(self) -> None:
         """Return the milliK device to LOCAL mode before disconnecting from the device."""

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -1,0 +1,149 @@
+"""
+IsoTech milliK Precision Thermometer, with any number of connected millisKanners
+"""
+from __future__ import annotations
+import re
+
+from msl.equipment.resources import register
+from msl.equipment.exceptions import IsotechError
+from msl.equipment.connection_serial import ConnectionSerial
+
+
+@register(manufacturer=r'Iso.*Tech.*', model=r'milli.*K.*', flags=re.IGNORECASE)
+class MilliK(ConnectionSerial):
+
+    def __init__(self, record) -> None:
+        """IsoTech MilliK Precision Thermometer.
+
+        Do not instantiate this class directly. Use the :meth:`~.EquipmentRecord.connect`
+        method to connect to the equipment.
+
+        Parameters
+        ----------
+        record : :class:`~.EquipmentRecord`
+            A record from an :ref:`equipment-database`.
+        """
+        super(MilliK, self).__init__(record)
+
+        self.set_exception_class(IsotechError)
+
+        self._connected_devices = None
+        self._num_devices = 0
+        self._channel_numbers = []
+
+        self.detect_channel_numbers()
+        self.write('millik:remote')  # use REMOTE mode to speed up communications
+
+    @property
+    def connected_devices(self) -> list:
+        """A list of information about the connected devices, as returned from the instrument(s) by the *IDN? command:
+        manufacturuer, model, serial number, firmware version
+        e.g. ['Isothermal Technology,millisKanner,21-P2593,2.01', 'Isothermal Technology,milliK,21-P2460,4.0.0']
+        """
+        return self._connected_devices
+
+    @property
+    def num_devices(self) -> int:
+        """The number of connected devices"""
+        return self._num_devices
+
+    @property
+    def channel_numbers(self) -> list:
+        """A list of available channel numbers: e.g. [1, 2] for a single milliK,
+        or [1, 10, 11, 12, 13, 14, 15, 16, 17] for a milliK connected to a single millisKanner, etc"""
+        return self._channel_numbers
+
+    def detect_channel_numbers(self) -> tuple[list, int, list]:
+        """Find the number of millisKanners connected, if any, and hence the valid channel numbers.
+        Up to 4 millisKanners can be connected to a single milliK.
+
+        Returns
+        -------
+        A list of the connected_devices, an integer for num_devices, ands a list of the channel_numbers
+        """
+        num_devices = 1
+        channel_numbers = [1, 2]
+        connected_devices = [self._get('mill:list?')]  # returns only first line of string response
+        while 'milliK' not in connected_devices[-1].split(','):  # the last device will be the milliK
+            connected_devices.append(self.read().rstrip())
+            channel_numbers += list(range(num_devices*10, num_devices*10+8))
+            num_devices += 1
+        if num_devices > 1:
+            channel_numbers.pop(1)  # removes channel 2 as this is used to connect millisKanner
+
+        self._connected_devices = connected_devices
+        self._num_devices = num_devices
+        self._channel_numbers = channel_numbers
+
+        return connected_devices, num_devices, channel_numbers
+
+    def resistance(self, channel, resis=200, current='norm', wire=4) -> float:
+        """Read the resistance, e.g. of a PRT or thermistor.
+
+        Parameters
+        ----------
+        channel : :class:`int`
+            The channel to read the resistance of
+        resis : :class:`int`, optional
+            The measurement range in ohms of probe being read
+        current : :class:`str`, optional
+            :data:`norm` to return normal (1 mA) sense current,
+            :data:`root2` for root2.
+            The sense current of the probe being read
+        wire : :class:`int`, optional
+            The wiring arrangement eg 3 or 4 wire
+
+        Returns
+        -------
+        :class:`float` or :class:`tuple` of :class:`float`
+            The resistance.
+        """
+        message = f'meas:res{channel}? {resis},{current},{wire}'
+        result = float(self._get(message))
+        if abs(result) > resis:
+            return float(0)
+        return result
+
+    def read_all_channels(self, resis=200, current='norm', wire=4) -> list[float, ...]:
+        """Read the resistance of all available channels.
+        Note that this method currently assumes the same probe type (e.g. PRT or thermistor) for all channels.
+        An update will be necessary if mixed probe types are used.
+
+        Parameters
+        ----------
+        resis : :class:`int`, optional
+            The measurement range in ohms of probe being read
+        current : :class:`str`, optional
+            :data:`norm` to return normal (1 mA) sense current,
+            :data:`root2` for root2.
+            The sense current of the probe being read
+        wire : :class:`int`, optional
+            The wiring arrangement eg 3 or 4 wire
+
+        Returns
+        -------
+        :class:`list`
+            A list of resistance values from all channels.
+        """
+        results = []
+        if not self.connected_devices:
+            self.detect_channel_numbers()
+
+        for c in self.channel_numbers:
+            data = self.resistance(c, resis=resis, current=current, wire=wire)
+            results.extend([data])
+
+        return results
+
+    def close_connection(self):
+        """Return milliK to LOCAL mode"""
+        self.write('millik:local')
+        self.disconnect()
+
+    def _get(self, message) -> str:
+        try:
+            ret = self.query(message).rstrip()
+        except ConnectionResetError:
+            return self._get(message)  # retry
+        else:
+            return ret

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -86,7 +86,6 @@ class MilliK:
             unless False in which case it uses root2*1 mA to determine self-heating effects.
             Thermistors always use 2 μA.
         :param fourwire: The wiring arrangement eg 3 or 4 wire.
-        :return: Returns the internal values set for range, current, and wiring.
         """
         if channel not in self.channel_numbers:
             self.raise_exception(f"Channel {channel} is not available in the current measurement setup")

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -38,20 +38,20 @@ class MilliK(ConnectionSerial):
 
     @property
     def connected_devices(self) -> list[str]:
-        """A list of information about the connected devices, as returned from the instrument(s) by the *IDN? command:
-        manufacturer, model, serial number, firmware version
-        e.g. ['Isothermal Technology,millisKanner,21-P2593,2.01', 'Isothermal Technology,milliK,21-P2460,4.0.0']
+        """A list of information about the connected devices (manufacturer, model, serial number, firmware version),
+        e.g. ['Isothermal Technology,millisKanner,21-P2593,2.01', 'Isothermal Technology,milliK,21-P2460,4.0.0'].
         """
+        # These are the strings that would be returned from each instrument by the *IDN? command
         return self._connected_devices
 
     @property
     def num_devices(self) -> int:
-        """The number of connected devices"""
+        """The number of connected devices."""
         return self._num_devices
 
     @property
     def channel_numbers(self) -> list[int]:
-        """A list of available channel numbers: e.g. [1, 2] for a single milliK,
+        """A list of available channel numbers, e.g. [1, 2] for a single milliK,
         or [1, 10, 11, 12, 13, 14, 15, 16, 17] for a milliK connected to a single millisKanner, etc.
         """
         return self._channel_numbers
@@ -59,7 +59,8 @@ class MilliK(ConnectionSerial):
     def detect_channel_numbers(self) -> tuple[list[str], int, list[int]]:
         """Find the number of millisKanners connected, if any, and hence the valid channel numbers.
         Up to 4 millisKanners can be connected to a single milliK.
-        Returns a list of the connected_devices, an integer for num_devices, ands a list of the channel_numbers
+        Returns a list of the :attr:`.connected_devices`, an integer for :attr:`.num_devices`,
+        and a list of the :attr:`.channel_numbers`.
         """
         num_devices = 1
         channel_numbers = [1, 2]
@@ -79,14 +80,14 @@ class MilliK(ConnectionSerial):
 
     def configure_resistance_measurement(self, range: float, *, norm: bool = True, fourwire: bool = True) \
             -> tuple[float, float, int]:
-        """Configure the sense mode for the milliK to measure resistance
+        """Configure the sense mode for the milliK to measure resistance.
 
         :param range: The measurement range in ohms. Selects from 115 Ohms, 460 Ohms and 500 kOhms.
         :param norm: The sense current to use for measurement. Defaults to use normal (1 mA) sense current,
             unless False in which case it uses root2*1 mA to determine self-heating effects.
             Thermistors always use 2 :math:`\\mu`A.
-        :param fourwire: The wiring arrangement eg 3 or 4 wire
-        :return: Returns the internal values set for range, current, and wiring
+        :param fourwire: The wiring arrangement eg 3 or 4 wire.
+        :return: Returns the internal values set for range, current, and wiring.
         """
         current = 'NORM' if norm else 'ROOT2'
         wire = 4 if fourwire else 3
@@ -107,12 +108,12 @@ class MilliK(ConnectionSerial):
 
         return float(range_set), current_set, wire_set
 
-    def read_channel(self, channel: int, n: int = 1) -> float or list[float]:
+    def read_channel(self, channel: int, n: int = 1) -> float | list[float]:
         """Initiate and report a measurement using the conditions defined by previous sense commands.
 
-        :param channel: The channel to read
-        :param n: The number of readings to make
-        :return: A list of n readings, each of which is an average of two readings
+        :param channel: The channel to read.
+        :param n: The number of readings to make.
+        :return: A list of n readings, or a single float value if only one reading is requested.
         """
         if channel not in self.channel_numbers:
             self.raise_exception(f"Channel {channel} is not available in the current measurement setup")
@@ -135,13 +136,10 @@ class MilliK(ConnectionSerial):
         """Read from all available channels using the conditions defined by previous sense commands.
         Note that this method currently assumes the same sensor type (e.g. PRT or thermistor) for all channels.
 
-        :param n: The number of readings to average for each returned value
-        :return: A list of values from all channels (in the order they appear in self.channel_numbers).
+        :param n: The number of readings to average for each returned value.
+        :return: A list of values from all channels (in the order they appear in :attr:`.channel_numbers`).
         """
         results = []
-        if not self.connected_devices:
-            self.detect_channel_numbers()
-
         for c in self.channel_numbers:
             readings = self.read_channel(c, n)
             if n == 1:  # readings is a single float value
@@ -152,7 +150,7 @@ class MilliK(ConnectionSerial):
         return results
 
     def disconnect(self) -> None:
-        """Return the milliK device to LOCAL mode"""
+        """Return the milliK device to LOCAL mode."""
         if self.serial.is_open:
             self.write('millik:local')
         super().disconnect()

--- a/msl/equipment/resources/isotech/millik.py
+++ b/msl/equipment/resources/isotech/millik.py
@@ -133,11 +133,11 @@ class MilliK:
 
         return readings
 
-    def read_all_channels(self, n: int = 1) -> list[float]:
+    def read_all_channels(self, n: int = 1) -> tuple[list[float], list[float]]:
         """Read from all configured channels using the conditions defined by :meth:`.configure_resistance_measurement`.
 
         :param n: The number of readings to average for each returned value.
-        :return: A list of values from all configured channels (in ascending order).
+        :return: A tuple of lists of channel numbers and readings from all configured channels.
         """
         results = []
         for c in sorted(self.channel_configuration):
@@ -147,7 +147,7 @@ class MilliK:
             else:       # average multiple readings
                 results.append(sum(readings)/len(readings))
 
-        return results
+        return sorted(self.channel_configuration), results
 
     def disconnect(self) -> None:
         """Return the milliK device to LOCAL mode before disconnecting from the device."""

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -27,19 +27,21 @@ record = EquipmentRecord(
 
 thermometer = record.connect()
 
-# Read information about the device
+# Print information about the device
 print('Number of devices connected:', thermometer.num_devices)
 print('Connected devices:', thermometer.connected_devices)
 print('Available channel numbers:', thermometer.channel_numbers)
 
-# Read the current resistance values using approximate resistance values for each channel
+# Configure channels using approximate resistance values for each channel
 r = [100, 470, 220, 820, 3300, 100, 1800, 13000]
 for i, res in enumerate(r, start=10):  # here the sensors are all on the first millisKanner only
-    thermometer.configure_resistance_measurement(range=res, norm=True, fourwire=True)
-    print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=2))
+    thermometer.configure_resistance_measurement(channel=i, range=res, norm=True, fourwire=True)
 
-# If all sensors are the same type then you can use the same setting for all channels, e.g. here for thermistors:
-thermometer.configure_resistance_measurement(range=2e5)
+# Read resistance for a specific channel, returning n readings
+i = 10
+print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
+
+# If all channels have been configured, then you can read them all at once
 print('Current resistance values for all channels:', thermometer.read_all_channels())
 
 # Disconnect from the milliK device and return the device to LOCAL mode

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -31,10 +31,12 @@ for i, res in enumerate(r, start=1):
 
 # Read resistance for a specific channel, returning n readings
 i = 2
-print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
+print(f'Resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
 
 # If all channels have been configured, then you can read them all at once
-print('Current resistance values for all channels:', thermometer.read_all_channels())
+ch, res = thermometer.read_all_channels()
+print("Configured channels:", ch)
+print('Resistance values:', res)
 
 # Disconnect from the milliK device and return the device to LOCAL mode
 thermometer.disconnect()

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -34,10 +34,9 @@ print('Available channel numbers:', thermometer.channel_numbers)
 
 # Read the current resistance values using approximate resistance values for each channel
 r = [100, 470, 220, 820, 3300, 100, 1800, 13000]
-for i in range(8):  # here the sensors are all on the first millisKanner only
-    thermometer.configure_resistance_measurement(range=r[i], norm=True, fourwire=True)
-    channel = i + 10
-    print(f'Current resistance value for Channel {channel}:', thermometer.read_channel(channel, n=2))
+for i, res in enumerate(r, start=10):  # here the sensors are all on the first millisKanner only
+    thermometer.configure_resistance_measurement(range=res, norm=True, fourwire=True)
+    print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=2))
 
 # If all sensors are the same type then you can use the same setting for all channels, e.g. here for thermistors:
 thermometer.configure_resistance_measurement(range=2e5)

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -1,0 +1,36 @@
+"""
+Example showing how to communicate with an IsoTech milliK Precision Thermometer,
+with any number of connected millisKanners.
+"""
+from msl.equipment import ConnectionRecord, EquipmentRecord
+
+record = EquipmentRecord(
+    manufacturer='Isotech',
+    model='milliK',
+    connection=ConnectionRecord(
+        address='COM9',  # change for your device
+        timeout=5,
+        properties={
+            'baud_rate': 9600,
+            'parity': None,
+            'start_bits': 1,
+            'stop_bits': 1,
+            'data_bits': 8,
+            'termination': '\r'
+        }  # Optional: change for your device
+    )
+)
+
+thermometer = record.connect()
+
+# Read information about the device
+print('Number of devices connected:', thermometer.num_devices)
+print('Connected devices:', thermometer.connected_devices)
+print('Available channel numbers:', thermometer.channel_numbers)
+
+# Read the current resistance values using a resistance value for thermistors
+print('Current resistance value for Channel 1:', thermometer.resistance(1, resis=20000, current='norm', wire=4))
+print('Current resistance values for all channels:', thermometer.read_all_channels(resis=20000, current='norm', wire=4))
+
+# Disconnect from the device and return the device to LOCAL mode
+thermometer.close_connection()

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -5,7 +5,7 @@ with any number of connected millisKanners.
 from msl.equipment import ConnectionRecord, EquipmentRecord
 
 record = EquipmentRecord(
-    manufacturer='Isotech',
+    manufacturer='IsoTech',
     model='milliK',
     connection=ConnectionRecord(
         address='COM9',  # change for your device

--- a/msl/examples/equipment/isotech/millik.py
+++ b/msl/examples/equipment/isotech/millik.py
@@ -2,7 +2,11 @@
 Example showing how to communicate with an IsoTech milliK Precision Thermometer,
 with any number of connected millisKanners.
 """
+import logging
+logging.basicConfig(level=logging.INFO)
+
 from msl.equipment import ConnectionRecord, EquipmentRecord
+
 
 record = EquipmentRecord(
     manufacturer='IsoTech',
@@ -28,9 +32,16 @@ print('Number of devices connected:', thermometer.num_devices)
 print('Connected devices:', thermometer.connected_devices)
 print('Available channel numbers:', thermometer.channel_numbers)
 
-# Read the current resistance values using a resistance value for thermistors
-print('Current resistance value for Channel 1:', thermometer.resistance(1, resis=20000, current='norm', wire=4))
-print('Current resistance values for all channels:', thermometer.read_all_channels(resis=20000, current='norm', wire=4))
+# Read the current resistance values using approximate resistance values for each channel
+r = [100, 470, 220, 820, 3300, 100, 1800, 13000]
+for i in range(8):  # here the sensors are all on the first millisKanner only
+    thermometer.configure_resistance_measurement(range=r[i], norm=True, fourwire=True)
+    channel = i + 10
+    print(f'Current resistance value for Channel {channel}:', thermometer.read_channel(channel, n=2))
 
-# Disconnect from the device and return the device to LOCAL mode
-thermometer.close_connection()
+# If all sensors are the same type then you can use the same setting for all channels, e.g. here for thermistors:
+thermometer.configure_resistance_measurement(range=2e5)
+print('Current resistance values for all channels:', thermometer.read_all_channels())
+
+# Disconnect from the milliK device and return the device to LOCAL mode
+thermometer.disconnect()

--- a/msl/examples/equipment/isotech/milliskanner.py
+++ b/msl/examples/equipment/isotech/milliskanner.py
@@ -1,6 +1,6 @@
 """
 Example showing how to communicate with an IsoTech milliK Precision Thermometer,
-connected via ethernet.
+with any number of connected millisKanners.
 """
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -12,8 +12,15 @@ record = EquipmentRecord(
     manufacturer='IsoTech',
     model='milliK',
     connection=ConnectionRecord(
-        address='TCP::10.12.102.30::1000',
+        address='COM9',  # change for your device
         timeout=5,
+        properties={
+            'baud_rate': 9600,
+            'parity': None,
+            'start_bits': 1,
+            'stop_bits': 1,
+            'data_bits': 8,
+        }  # Optional: change for your device
     )
 )
 
@@ -25,16 +32,18 @@ print('Connected devices:', thermometer.connected_devices)
 print('Available channel numbers:', thermometer.channel_numbers)
 
 # Configure channels using approximate resistance values for each channel
-r = [130, 13000]
-for i, res in enumerate(r, start=1):
-    thermometer.configure_resistance_measurement(channel=i, meas_range=res, norm=True, fourwire=False)
+r = [13000, 470, 220, 820, 3300, 100, 1800, 100]
+for i, res in enumerate(r, start=10):  # here the sensors are all on the first millisKanner only
+    thermometer.configure_resistance_measurement(channel=i, meas_range=res, norm=True, fourwire=True)
 
 # Read resistance for a specific channel, returning n readings
-i = 2
+i = 13
 print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
 
-# If all channels have been configured, then you can read them all at once
-print('Current resistance values for all channels:', thermometer.read_all_channels())
+# print(thermometer.channel_configuration)
+
+# Once the desired channels have been configured, then you can read them all at once
+print('Current resistance values for all configured channels:', thermometer.read_all_channels())
 
 # Disconnect from the milliK device and return the device to LOCAL mode
 thermometer.disconnect()

--- a/msl/examples/equipment/isotech/milliskanner.py
+++ b/msl/examples/equipment/isotech/milliskanner.py
@@ -38,12 +38,14 @@ for i, res in enumerate(r, start=10):  # here the sensors are all on the first m
 
 # Read resistance for a specific channel, returning n readings
 i = 13
-print(f'Current resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
+print(f'Resistance value for Channel {i}:', thermometer.read_channel(i, n=5))
 
 # print(thermometer.channel_configuration)
 
 # Once the desired channels have been configured, then you can read them all at once
-print('Current resistance values for all configured channels:', thermometer.read_all_channels())
+ch, res = thermometer.read_all_channels()
+print("Configured channels:", ch)
+print('Resistance values:', res)
 
 # Disconnect from the milliK device and return the device to LOCAL mode
 thermometer.disconnect()

--- a/tests/resources/test_init.py
+++ b/tests/resources/test_init.py
@@ -200,7 +200,6 @@ def test_find_resource_class():
 
     for man in ('IsoTech', 'Isothermal Technology', 'Isothermal Technology Limited'):
         for mod in ('milliK', 'millisKanner'):
-            print(man, mod)
             record = ConnectionRecord(manufacturer=man, model=mod, backend=Backend.MSL)
             cls = resources.find_resource_class(record)
             assert cls is resources.isotech.millik.MilliK

--- a/tests/resources/test_init.py
+++ b/tests/resources/test_init.py
@@ -197,3 +197,10 @@ def test_find_resource_class():
             record = ConnectionRecord(manufacturer=man, model=mod, backend=Backend.MSL)
             cls = resources.find_resource_class(record)
             assert cls is resources.greisinger.GMH3000
+
+    for man in ('IsoTech', 'Isothermal Technology', 'Isothermal Technology Limited'):
+        for mod in ('milliK', 'millisKanner'):
+            print(man, mod)
+            record = ConnectionRecord(manufacturer=man, model=mod, backend=Backend.MSL)
+            cls = resources.find_resource_class(record)
+            assert cls is resources.isotech.millik.MilliK


### PR DESCRIPTION
The IsoTech milliK resource class can be used to read resistance values from a milliK and any number of connected millisKanner devices. The class supports measurement of PRTs and/or thermistors. Voltage measurement (e.g. for thermocouples) will need a subsequent update.